### PR TITLE
Export instance of jade

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,3 +36,4 @@ Filter.prototype.build = function (readTree, destDir) {
 }
 
 module.exports = Filter
+module.exports.jade = jade


### PR DESCRIPTION
Hi!

As you probably know, `require` in an npm dependency returns a different instance than `require` in the project that depends on it.

So it's not possible to customize the Jade instance used by this plugin in that way – `require('jade').filters.babel = function(t){...}` adds the filter to the wrong instance.
